### PR TITLE
Update current_price_among_x_lowest_next_y_hours.json

### DIFF
--- a/.homeycompose/flow/conditions/current_price_among_x_lowest_next_y_hours.json
+++ b/.homeycompose/flow/conditions/current_price_among_x_lowest_next_y_hours.json
@@ -32,7 +32,7 @@
       "name": "next_hours",
       "type": "number",
       "min": 1,
-      "max": 23,
+      "max": 36,
       "step": 1,
       "title": {
         "en": "Hours"


### PR DESCRIPTION
Added possibility to extend the period to 36 hours. Which is all the "know" hours when the prices are release from nordpool.